### PR TITLE
Provides a utility script to restart the asa server during play time

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository provides a step by step guide for Linux administrators to host A
   * [Debug Mode](#debug-mode)
   * [Applying server updates](#applying-server-updates)
   * [Daily restarts](#daily-restarts)
+  * [Restarts during play time](#restarts-during-play-time)
   * [Executing RCON commands](#executing-rcon-commands)
 * [Setting up a second server / cluster](#setting-up-a-second-server--cluster)
 * [Adding Mods](#adding-mods)
@@ -338,6 +339,18 @@ Explanation:
 Read more about the crontab syntax [here](https://www.adminschoice.com/crontab-quick-reference).
 
 **NOTE:** The first 4 lines execute RCON commands, which requires you to have a working RCON setup. Please follow the instructions in section "[Executing RCON commands](#executing-rcon-commands)" to
+ensure you can execute RCON commands.
+
+### Restarts during play time
+If server updates should be applied during play time, feel free to checkout the utility script under `util/check_ASAserver_update.sh`. In case a server update is detected with `steamcmd`, the server is restarted during play time after a specified grace period. It will be restarted immediately if no player is online.
+The script should be executed on the docker host system and needs two parameters:
+* `-s` for the server's container name, i. e. `asa-server-1`
+* `-g` for the grace period
+
+For more details see `./util/check_ASAserver_update.sh --help`.
+
+**NOTE1:** Similar to setup in [Daily restarts](#daily-restarts), a crontab configuration can be set up to check for updates periodically. Keep in mind to choose greater intervals of your crontab compared to your grace period.
+**NOTE2:** The script requires a working RCON setup in order to check for online players. Please follow the instructions in section "[Executing RCON commands](#executing-rcon-commands)" to
 ensure you can execute RCON commands.
 
 ### Executing RCON commands

--- a/util/check_ASAserver_update.sh
+++ b/util/check_ASAserver_update.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+##
+## Checks for available ASA server updates
+##
+STEAM_CMD="./steamcmd/steamcmd.sh +@ShutdownOnFailedCommand 1 +@NoPromptForPassword 1 +login anonymous +app_info_print 2430930 +quit"
+
+function show_help() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+    -g, --grace-period <arg>   Defines the grace period after which the server restart happens
+                               Immediate restart without online players
+                               Syntax follows syntax of "sleep" command
+    -s, --server <arg>         Specifices the ASA server container
+    -h, --help                 Show this help message and exit
+EOF
+}
+
+function determine_current_version(){
+    # current version
+    CURRENT_VERSION=$(docker exec -t ${1} bash -c "grep buildid ./server-files/steamapps/appmanifest_2430930.acf | cut -d'\"' -f4 | xargs")
+    if [[ -z "${CURRENT_VERSION}" ]]
+    then
+	echo "Current version could not be determined!"
+	exit 1
+    fi
+    echo "Installed ASA server (2430930) buildid: ${CURRENT_VERSION}"
+}
+
+function determine_upstream_version(){
+    # upstream version
+    UPSTREAM_VERSION=$(docker exec -t ${1} bash -c "${STEAM_CMD} | grep -A 3 '\"public\"' | grep buildid | cut -d'\"' -f4 | xargs")
+    if [[ -z "${UPSTREAM_VERSION}" ]]
+    then
+	echo "Upstream version could not be determined!"
+	exit 1
+    fi
+    echo "Available ASA server (2430930) buildid: ${UPSTREAM_VERSION}"
+
+}
+
+function compare_versions(){
+    # comparison $1 -> CURRENT_VERSION, $2 -> UPSTREAM_VERSION
+    if [[ "${1}" == "${2}" ]]
+    then
+	echo "Installed ASA server (2430930) is current!"
+        exit 0
+    else
+	echo "ASA server (2430930) update available!"
+    fi
+}
+
+function update(){
+    # check upon online players
+    # $1 -> SERVER $2 -> PERIOD
+    if [[ $(docker exec -t ${1} bash -c "asa-ctrl rcon --exec 'listplayers'" | xargs) == "No Players Connected" ]]
+    then
+	echo "Restarting server ${1} immediately without online players..."
+	docker restart ${1}
+    else
+	echo "Initiated restart in ${2} due to online players..."
+	docker exec -t ${1} bash -c "asa-ctrl rcon --exec 'serverchat Server is restarting in ${2} due to updates...'"
+	sleep ${2}
+	echo "Restarting server ${1} now (after grace period)..."
+	docker exec -t ${1} bash -c "asa-ctrl rcon --exec 'serverchat Server is restarting NOW due to updates...'"
+	docker restart ${1}
+    fi
+}
+
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -g|--grace-period)
+            PERIOD="$2"
+            shift 2
+            ;;
+        -s|--server)
+            SERVER="$2"
+            shift 2
+            ;;
+        -h|--help)
+            help=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$help" = true ]]; then
+    show_help
+    exit 0
+fi
+determine_current_version ${SERVER}
+determine_upstream_version ${SERVER}
+compare_versions ${CURRENT_VERSION} ${UPSTREAM_VERSION}
+update ${SERVER} ${PERIOD}


### PR DESCRIPTION
As discussed in #139, I created a first draft to showcase an utility script, which restarts the server during play time. This will enable almost immediate server updates with the disadvantage of game interruption.

The script can be used in a crontab similar to the [Daily restarts](https://github.com/mschnitzer/ark-survival-ascended-linux-container-image?tab=readme-ov-file#daily-restarts). 

As parameters a grace period should be provided in order to give players time to prepare for  the restart. It also needs the container name, for which the update should be applied. This helps to support multiple servers differently.

I understand the wishes in #139, although for me it feels more like a infrastructure task like  the daily restarts than this should be part of the docker image itself. It feels more like a external utility/script for that use case and it has to be decided, if it really should become part of the repo or maybe only a hint in the `README.md`. 

For me everything is fine as long as I am not forced to use the auto-upgrade. As I wrote, I am not a big fan of interruption during the game session. But there are a bunch of different other use cases where this might come in handy. 

Nevertheless I will leave it here for discussion!